### PR TITLE
feat: add group editing dialog and implement update functionality

### DIFF
--- a/GroupSplit.API/Endpoints/GroupApi.cs
+++ b/GroupSplit.API/Endpoints/GroupApi.cs
@@ -1,6 +1,7 @@
 ﻿using GroupSplit.API.Services;
 using GroupSplit.Data.Entities;
 using GroupSplit.Shared;
+using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 using Microsoft.EntityFrameworkCore;
 
 namespace GroupSplit.API.Endpoints;
@@ -20,6 +21,7 @@ public static class GroupApi
             group.MapCreate();
             group.MapGetAllGroups();
             group.MapGetGroup();
+            group.MapUpdateGroup();
             group.MapGetMembers();
             group.MapAddMember();
 
@@ -75,6 +77,31 @@ public static class GroupApi
                 .WithName("GetGroup")
                 .Produces<GroupResponse>()
                 .ProducesProblem(StatusCodes.Status404NotFound);
+        }
+        
+        private RouteHandlerBuilder MapUpdateGroup()
+        {
+            return group.MapPatch("{id:guid}", async (
+                Guid id,
+                JsonPatchDocument<CreateGroupRequest> patchDocument,
+                IGroupService groupService,
+                CancellationToken ct) =>
+            {
+                var groups = await groupService.GetGroupById(id, ct);
+                var groupUpdateRequest = await (from t in groups
+                    select new CreateGroupRequest
+                    {
+                        Name = t.Name
+                    }).FirstOrDefaultAsync(ct);
+
+                if (groupUpdateRequest is null) return Results.NotFound();
+
+                patchDocument.ApplyTo(groupUpdateRequest);
+
+                await groupService.UpdateGroup(id, groupUpdateRequest, ct);
+
+                return Results.Ok();
+            }).WithName("UpdateGroup");
         }
 
         private RouteHandlerBuilder MapGetMembers()

--- a/GroupSplit.API/Services/GroupService.cs
+++ b/GroupSplit.API/Services/GroupService.cs
@@ -22,6 +22,8 @@ public interface IGroupService
     /// </summary>
     Task<IQueryable<Group>> GetGroupById(Guid groupId, CancellationToken cancellationToken = default);
 
+    Task UpdateGroup(Guid groupId, CreateGroupRequest request, CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Gets the members of a group by ID
     /// </summary>
@@ -68,6 +70,20 @@ public class GroupService(IUserService userService, AppDbContext context) : IGro
         return from g in await GetAllGroups(cancellationToken)
                where g.Id == groupId
                select g;
+    }
+
+    public async Task UpdateGroup(Guid groupId, CreateGroupRequest request, CancellationToken cancellationToken = default)
+    {
+        var group = await GetGroupById(groupId, cancellationToken);
+        
+        var existingGroup = await group.FirstOrDefaultAsync(cancellationToken);
+        
+        if (existingGroup is null)
+            throw new Exception("Group was not found");
+        
+        existingGroup.Name = request.Name;
+        
+        await context.SaveChangesAsync(cancellationToken);
     }
 
     public async Task<IQueryable<User>> GetGroupMembers(Guid groupId, CancellationToken cancellationToken = default)

--- a/GroupSplit.App/GroupSplit.App.Shared/Components/UpdateGroupDialog.razor
+++ b/GroupSplit.App/GroupSplit.App.Shared/Components/UpdateGroupDialog.razor
@@ -1,0 +1,87 @@
+@using GroupSplit.Shared
+@using Microsoft.AspNetCore.JsonPatch
+@namespace GroupSplit.App.Shared.Components
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h5" Class="font-weight-bold">
+            @MudDialog.Title
+        </MudText>
+    </TitleContent>
+
+    <DialogContent>
+        <MudForm @ref="@form" Model="@editModel">
+            <MudTextField
+                @bind-Value="editModel.Name"
+                For="@(() => editModel.Name)"
+                Label="Name"
+                Immediate="true"
+            />
+        </MudForm>
+    </DialogContent>
+
+    <DialogActions>
+        <MudButton OnClick="@Cancel">Cancel</MudButton>
+
+        <MudButton Color="Color.Primary" Disabled="@loading" OnClick="@Submit">
+            Submit
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter]
+    public GroupResponse Group { get; set; } = null!;
+
+    MudForm form;
+    private bool loading = false;
+
+    private CreateGroupRequest editModel = new();
+    private CreateGroupRequest originalModel = new();
+
+    protected override void OnInitialized()
+    {
+        // Map GroupResponse → CreateGroupRequest
+        originalModel = new CreateGroupRequest
+        {
+            Name = Group.Name
+        };
+
+        // Clone into editable form model
+        editModel = new CreateGroupRequest
+        {
+            Name = Group.Name
+        };
+    }
+
+    private async Task Submit()
+    {
+        await form.Validate();
+
+        if (!form.IsValid)
+            return;
+
+        loading = true;
+
+        var patch = BuildPatch(originalModel, editModel);
+
+        MudDialog.Close(DialogResult.Ok(patch));
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+
+    private JsonPatchDocument<CreateGroupRequest> BuildPatch(
+        CreateGroupRequest original,
+        CreateGroupRequest updated)
+    {
+        var patch = new JsonPatchDocument<CreateGroupRequest>();
+
+        if (original.Name != updated.Name)
+            patch.Replace(x => x.Name, updated.Name);
+
+        return patch;
+    }
+}

--- a/GroupSplit.App/GroupSplit.App.Shared/Pages/Groups.razor
+++ b/GroupSplit.App/GroupSplit.App.Shared/Pages/Groups.razor
@@ -1,6 +1,7 @@
 @page "/groups"
 @using GroupSplit.App.Shared.Components
 @using GroupSplit.Shared
+@using Microsoft.AspNetCore.JsonPatch
 @inject IGroupsClient GroupsClient
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
@@ -27,6 +28,12 @@
                        StartIcon="@Icons.Material.Outlined.Settings"
                        OnClick="ManageRules">
                 Manage Rules
+            </MudButton>
+            <MudButton Variant="Variant.Outlined"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Outlined.Edit"
+                       OnClick="@OpenUpdateGroupDialog">
+                Edit Group
             </MudButton>
             @if (!_isSelectedGroupArchived)
             {
@@ -351,6 +358,30 @@
 
         var group = await GroupsClient.CreateGroupAsync(request);
         UserGroups.Add(group);
+    }
+    
+    private async Task OpenUpdateGroupDialog()
+    {
+        var parameters = new DialogParameters
+        {
+            { "Group", UserGroups.First(x => x.Id == _selectedGroupId) }
+        };
+
+        var dialog = await DialogService.ShowAsync<UpdateGroupDialog>(
+            "Edit Group",
+            parameters,
+            new DialogOptions { FullWidth = true }
+        );
+
+        var result = await dialog.Result;
+
+        if (result is null || result.Canceled)
+            return;
+        
+        if (result.Data is JsonPatchDocument<CreateGroupRequest> patch)
+        {
+            await GroupsClient.UpdateGroupAsync(_selectedGroupId, patch);
+        }
     }
 
     private class DebtInfo


### PR DESCRIPTION
- Introduce `UpdateGroupDialog` component with form validation and JSON patch generation.
- Add "Edit Group" button in `Groups.razor` to open the dialog for modifying group details.
- Extend `GroupService` with `UpdateGroup` method to handle group updates.
- Implement `MapUpdateGroup` endpoint in API for applying JSON patch updates to groups.